### PR TITLE
Fix Actions CI to account for tests

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -55,10 +55,12 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      # Tests are only added in Debug builds
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        ${{ matrix.build_type == 'Debug' && '-DBUILD_TESTS=ON' || '' }}
         -S ${{ github.workspace }}
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.26)
 project(FSM CXX)
 add_executable(FSM src/main.cpp)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Add third-party libraries
 add_subdirectory(thirdparty)
 


### PR DESCRIPTION
Set `-DBUILD_TESTS=ON` for Debug builds only.

Also set C++ standard to 17 in root CMakeLists.txt since macos Debug build was complaining about `constexpr` used by doctest.